### PR TITLE
docs(code): add workflow example to highlight the actions

### DIFF
--- a/docs/markdown/10-code/00-definition.md
+++ b/docs/markdown/10-code/00-definition.md
@@ -13,6 +13,77 @@
 
 ##--##
 
+<!-- .slide: class="with-code" -->
+
+# GitHub Actions Workflow
+
+Where are the actions?
+
+```yaml
+name: 'Link Checker: All English'
+on: push
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.13.x
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Gather files changed
+        uses: trilom/file-changes-action@a6ca26c14274c33b15e6499323aac178af06ad4b
+        with:
+          fileOutput: 'json'
+      - name: Show files changed
+        run: cat $HOME/files.json
+      - name: Link check (warnings, changed files)
+        run: |
+          ./script/rendered-content-link-checker.mjs \
+            --language en \
+            --max 100 \
+            --check-anchors \
+            --check-images \
+            --verbose \
+            --list $HOME/files.json
+      - name: Link check (critical, all files)
+        run: |
+          ./script/rendered-content-link-checker.mjs \
+            --language en \
+            --exit \
+            --verbose \
+            --check-images \
+            --level critical
+```
+
+##--##
+
+<!-- .slide: class="with-code" -->
+
+# GitHub Actions Workflow
+
+Here
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.13.x
+          cache: npm
+      - name: Gather files changed
+        uses: trilom/file-changes-action@a6ca26c14274c33b15e6499323aac178af06ad4b
+        with:
+          fileOutput: 'json'
+```
+
+##--##
+
 # What kind of actions?
 
 - Transform existing files


### PR DESCRIPTION
The first version of this slide enables us to highlight actions inside a workflow just after defining an action.

The final version will occur with the new theme version (see #2)